### PR TITLE
Phoenix QueryServer 6.0.0-1.0

### DIFF
--- a/phoenix-queryserver-assembly/pom.xml
+++ b/phoenix-queryserver-assembly/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.phoenix</groupId>
         <artifactId>phoenix-queryserver-parent</artifactId>
-        <version>6.0.0-0.0</version>
+        <version>6.0.0-1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>phoenix-queryserver-assembly</artifactId>

--- a/phoenix-queryserver-client/pom.xml
+++ b/phoenix-queryserver-client/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-queryserver-parent</artifactId>
-    <version>6.0.0-0.0</version>
+    <version>6.0.0-1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-queryserver-client</artifactId>

--- a/phoenix-queryserver-it/pom.xml
+++ b/phoenix-queryserver-it/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-queryserver-parent</artifactId>
-    <version>6.0.0-0.0</version>
+    <version>6.0.0-1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-queryserver-it</artifactId>

--- a/phoenix-queryserver-load-balancer/pom.xml
+++ b/phoenix-queryserver-load-balancer/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-queryserver-parent</artifactId>
-    <version>6.0.0-0.0</version>
+    <version>6.0.0-1.0-SNAPSHOT</version>
   </parent>
   <artifactId>phoenix-queryserver-load-balancer</artifactId>
   <name>Phoenix Query Server Load Balancer</name>

--- a/phoenix-queryserver-orchestrator/pom.xml
+++ b/phoenix-queryserver-orchestrator/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>phoenix-queryserver-parent</artifactId>
         <groupId>org.apache.phoenix</groupId>
-        <version>6.0.0-0.0</version>
+        <version>6.0.0-1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>phoenix-queryserver-orchestrator</artifactId>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-queryserver-parent</artifactId>
-    <version>6.0.0-0.0</version>
+    <version>6.0.0-1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>phoenix-queryserver</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <!-- General Properties -->
         <top.dir>${project.basedir}</top.dir>
 
-        <phoenix.version>5.1.3-1.0</phoenix.version>
+        <phoenix.version>5.1.3-2.0-SNAPSHOT</phoenix.version>
 
         <!-- Hadoop/Hbase Versions -->
         <hbase.version>2.1.10-1.0</hbase.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
         <!-- Hadoop/Hbase Versions -->
         <hbase.version>2.1.10-1.0</hbase.version>
-        <hadoop.version>3.1.1-0.0</hadoop.version>
+        <hadoop.version>3.1.4-1.0-SNAPSHOT</hadoop.version>
         <phoenix.client.artifactid>phoenix-client-hbase-2.1</phoenix.client.artifactid>
 
         <!-- Dependency versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <phoenix.version>5.1.3-2.0-SNAPSHOT</phoenix.version>
 
         <!-- Hadoop/Hbase Versions -->
-        <hbase.version>2.1.10-1.0</hbase.version>
+        <hbase.version>2.1.10-2.0-SNAPSHOT</hbase.version>
         <hadoop.version>3.1.4-1.0-SNAPSHOT</hadoop.version>
         <phoenix.client.artifactid>phoenix-client-hbase-2.1</phoenix.client.artifactid>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix-queryserver-parent</artifactId>
-    <version>6.0.0-0.0</version>
+    <version>6.0.0-1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Phoenix Query Server Maven Parent Project</name>
 

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Phoenix QueryServer Notes
 
-The version 6.0.0-0.0 of Phoenix QueryServer is based on the `6.0.0` tag of the Apache [repository](https://github.com/apache/phoenix-queryserver/tree/6.0.0).
+The version 6.0.0-1.0-SNAPSHOT of Phoenix QueryServer is based on the `6.0.0` tag of the Apache [repository](https://github.com/apache/phoenix-queryserver/tree/6.0.0).
 
 
 # Build a queryserver with TDP versions
@@ -10,7 +10,7 @@ mvn clean package -Dpackage.phoenix.client -pl '!phoenix-queryserver-it' -DskipT
 ```
 
 
-This command generates a `tar.gz` file of the release at `phoenix-queryserver-assembly/target/phoenix-queryserver-6.0.0-0.0-bin.tar.gz`
+This command generates a `tar.gz` file of the release at `phoenix-queryserver-assembly/target/phoenix-queryserver-6.0.0-1.0-SNAPSHOT-bin.tar.gz`
 
 ## Testing parameters
 


### PR DESCRIPTION
Relates to https://github.com/TOSIT-IO/TDP/pull/90

Included in the PR:

Bump 3 TDP dependencies (hadoop, hbase and phoenix) to their TDP 1.1 versions.

Not included in the PR, but included in this new -1.0 : https://github.com/TOSIT-IO/phoenix-queryserver/pull/4

These backports has been included in branch 6.0.0 but not in the release afaik